### PR TITLE
Fixing sleep interruption noise

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.3.1
+version=1.3.2
 curator.version=4.3.0

--- a/tw-leader-selector-starter/build.gradle
+++ b/tw-leader-selector-starter/build.gradle
@@ -32,8 +32,8 @@ dockerCompose {
     // waitForTcpPorts = false
 
     // Set to true if you have anomalies
-    stopContainers = false
-    removeContainers = false
+    stopContainers = true
+    removeContainers = true
 }
 
 test {

--- a/tw-leader-selector/src/main/java/com/transferwise/common/leaderselector/LeaderSelectorV2.java
+++ b/tw-leader-selector/src/main/java/com/transferwise/common/leaderselector/LeaderSelectorV2.java
@@ -207,7 +207,12 @@ public class LeaderSelectorV2 implements LeaderSelectorLifecycle {
   }
 
   private void sleep(long ms) {
-    ExceptionUtils.doUnchecked(() -> Thread.sleep(ms));
+    try {
+      Thread.sleep(ms);
+    } catch (InterruptedException ignored) {
+      // We have other mechanisms to make sure, that things get closed down when executor(s) are shutdown.
+      Thread.interrupted();
+    }
   }
 
   private long currentTimeMillis() {
@@ -226,8 +231,7 @@ public class LeaderSelectorV2 implements LeaderSelectorLifecycle {
     private ExecutorService executorService;
 
     /**
-     * The minimum interval between taking leaderships. It is non-zero by default, so novice users can not overload the Zookeeper cluster. It 
-     * is very
+     * The minimum interval between taking leaderships. It is non-zero by default, so novice users can not overload the Zookeeper cluster. It is very
      * rarely needed to be changed.
      */
 
@@ -242,9 +246,9 @@ public class LeaderSelectorV2 implements LeaderSelectorLifecycle {
     private Duration tickDuration = Duration.ofSeconds(2);
     /**
      * Number of work iterations until the leader selector will be automatically stopped.
-     * 
+     *
      * <p>&lt;null> has special value of indefinite iterations until explicit stop is called.
-     * 
+     *
      * <p>This parameter can be useful for one-time workloads.
      */
     @Setter


### PR DESCRIPTION
## Context

Noticed some rare noise when executors are stopped very quickly at shutdown.

```
15:47:12.260 [g-tw-base-t-1-tw-tkms-poller-0_0] ERROR c.t.common.leaderselector.LeaderSelectorV2 - java.lang.InterruptedException: sleep interrupted
java.lang.RuntimeException: java.lang.InterruptedException: sleep interrupted
        at com.transferwise.common.baseutils.ExceptionUtils.toUnchecked(ExceptionUtils.java:47)
        at com.transferwise.common.baseutils.ExceptionUtils.doUnchecked(ExceptionUtils.java:24)
        at com.transferwise.common.leaderselector.LeaderSelectorV2.sleep(LeaderSelectorV2.java:210)
        at com.transferwise.common.leaderselector.LeaderSelectorV2.lambda$start$0(LeaderSelectorV2.java:51)
        at com.transferwise.common.baseutils.concurrency.ThreadNamingExecutorServiceWrapper.lambda$wrap$1(ThreadNamingExecutorServiceWrapper.java:112)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.InterruptedException: sleep interrupted
        at java.lang.Thread.sleep(Native Method)
        at com.transferwise.common.leaderselector.LeaderSelectorV2.lambda$sleep$8(LeaderSelectorV2.java:210)
        at com.transferwise.common.baseutils.ExceptionUtils.doUnchecked(ExceptionUtils.java:22)
        ... 8 common frames omitted
```


### Changes

It is rare, but possible, that our sleeps get interrupted when someone is closing executors too early or we have configured long sleep times.

We will ignore those interruptions as we have separate mechanisms to close everything down.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
