### PR TITLE
Support case if CuratorFramework is not configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.0] = 2022-05-31
+## [1.8.0] - 2022-11-16
+- Support `tw-curator.disabled: true` case, so users of this library does not have to introduce Zookeeper as a 
+dependency. E.g. `Wise Kafka Processor` can support database cleanup that depends on leader selection provided by this
+library. But `Wise Kafka Processor` can also be used without a DB dependency, in which case we want to avoid introducing 
+the dependency on Zookeeper.
+
+## [1.7.0] - 2022-05-31
 - Dependencies upgrades.
 
 ## [1.6.0] - 2021-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.8.0] - 2022-11-16
 - Only autoconfigure beans if CuratorFramework is available. With this change, users of this library does not always 
-have to introduce Zookeeper as a dependency. E.g. `Wise Kafka Processor` can support database cleanup that depends on 
-leader selection provided by this library. But `Wise Kafka Processor` can also be used without a DB dependency, in which
-case we want to avoid introducing the dependency on Zookeeper.
+have to introduce Zookeeper as a dependency.
 
 ## [1.7.0] - 2022-05-31
 - Dependencies upgrades.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.8.0] - 2022-11-16
-- Support `tw-curator.disabled: true` case, so users of this library does not have to introduce Zookeeper as a 
-dependency. E.g. `Wise Kafka Processor` can support database cleanup that depends on leader selection provided by this
-library. But `Wise Kafka Processor` can also be used without a DB dependency, in which case we want to avoid introducing 
-the dependency on Zookeeper.
+- Only autoconfigure beans if CuratorFramework is available. With this change, users of this library does not always 
+have to introduce Zookeeper as a dependency. E.g. `Wise Kafka Processor` can support database cleanup that depends on 
+leader selection provided by this library. But `Wise Kafka Processor` can also be used without a DB dependency, in which
+case we want to avoid introducing the dependency on Zookeeper.
 
 ## [1.7.0] - 2022-05-31
 - Dependencies upgrades.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ implementation "com.transferwise.common:tw-leader-selector"
 runtimeOnly "com.transferwise.common:tw-leader-selector-starter"
 ```
 
+Then configure the Zookeeper address:
+
+```yaml
+tw-curator.zookeeper-connect-string: ${ENV_ZOOKEEPER_CONNECT_STRING}
+```
+
+Libraries depending on tw-leader-selector might have use cases in which leader selection is not required and they want
+to avoid introducing the Zookeeper dependency. In that case use the following configuration:
+
+```yaml
+tw-curator.disabled: true
+```
+
 ### Distributed lock
 
 Even when the library is named as "leader selector", it can be used just for distributed locking as well.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ tw-curator.zookeeper-connect-string: ${ENV_ZOOKEEPER_CONNECT_STRING}
 ```
 
 Libraries depending on tw-leader-selector might have use cases in which leader selection is not required and they want
-to avoid introducing the Zookeeper dependency. In that case use the following configuration:
+to avoid introducing the Zookeeper dependency. In that the service should not define the property 
+`tw-curator.zookeeper-connect-string`. Not defining the Zookeeper address is enough, but for explicitness, one can 
+define the following property instead:
 
 ```yaml
 tw-curator.disabled: true

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -10,7 +10,7 @@ ext {
             testContainers                  : 'org.testcontainers:testcontainers:1.17.2',
             twBaseUtils                     : 'com.transferwise.common:tw-base-utils:1.7.1',
             twContext                       : 'com.transferwise.common:tw-context:0.11.1',
-            twCuratorStarter                : 'com.transferwise.common:tw-curator-starter:0.3.2',
+            twCuratorStarter                : 'com.transferwise.common:tw-curator-starter:0.4.0',
             zookeeper                       : 'org.apache.zookeeper:zookeeper:3.8.0',
 
             // versions managed by spring-boot-dependencies platform

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.7.0
+version=1.8.0

--- a/tw-leader-selector-starter/build.gradle
+++ b/tw-leader-selector-starter/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     api project(":tw-leader-selector:")
     
     implementation libraries.springBootStarter
+    implementation libraries.curatorRecipes
 
     runtimeOnly libraries.twCuratorStarter
 

--- a/tw-leader-selector-starter/src/main/java/com/transferwise/common/leaderselector/TwLeaderSelectorAutoConfiguration.java
+++ b/tw-leader-selector-starter/src/main/java/com/transferwise/common/leaderselector/TwLeaderSelectorAutoConfiguration.java
@@ -1,10 +1,13 @@
 package com.transferwise.common.leaderselector;
 
+import org.apache.curator.framework.CuratorFramework;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@ConditionalOnBean(CuratorFramework.class)
 public class TwLeaderSelectorAutoConfiguration {
 
   @Bean


### PR DESCRIPTION
## Context

Users of this library does not have to introduce Zookeeper as a dependency.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
