### PR TITLE
[APPENG-763] Update matrix tests to run with SB 3.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
+          - 3.2.2
           - 3.1.2
           - 3.0.7
           - 2.7.13
-          - 2.6.15
     container:
       image: azul/zulu-openjdk:17
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.10.2] - 2024-02-21
+
+### Changed
+* - Added support for Spring Boot 3.2.
+    - Updated dependencies.
+
 ## [1.10.1] - 2023-08-01
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -10,9 +10,9 @@ ext {
             spotbugsAnnotations             : "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}",
             springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:${springBootVersion}",
             testContainers                  : 'org.testcontainers:testcontainers:1.18.0',
-            twBaseUtils                     : 'com.transferwise.common:tw-base-utils:1.10.1',
-            twContext                       : 'com.transferwise.common:tw-context:0.12.0',
-            twCuratorStarter                : 'com.transferwise.common:tw-curator-starter:0.5.0',
+            twBaseUtils                     : 'com.transferwise.common:tw-base-utils:1.12.3',
+            twContext                       : 'com.transferwise.common:tw-context:1.0.1',
+            twCuratorStarter                : 'com.transferwise.common:tw-curator-starter:0.5.1',
 
             // versions managed by spring-boot-dependencies platform
             commonsLang3                    : 'org.apache.commons:commons-lang3',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.10.1
+version=1.10.2


### PR DESCRIPTION
## Context

Wise is now supporting Spring Boot 3.2 so matrix tests need to be updated to run with the new version.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [APPENG-763](https://transferwise.atlassian.net/browse/APPENG-763)

### Update platform libraries matrix tests to run with boot 3.2

>Keeping track of all the libraries that have received support for Boot 3.2 here:
>[https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit#gid=242339130|https://docs.google.com/spreadsheets/d/1cogv7V6ofZv1urcBYYrj91f3VzKg-e92DltiiRgqndc/edit#gid=242339130|smart-link] 


[APPENG-763]: https://transferwise.atlassian.net/browse/APPENG-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ